### PR TITLE
Adding apple touch icon

### DIFF
--- a/templates/head.html
+++ b/templates/head.html
@@ -5,6 +5,7 @@
 <meta content="width=device-width,initial-scale=1" name="viewport">
 
 <link rel="icon" type="image/png" href="${url_base}/static/images/favicon.png" />
+<link rel="apple-touch-icon" href="${url_base}/static/images/logo_bg.png" />
 
 <link href="${url_base}/static/css/themes/${uitheme or 'Default'}.css?v=001" rel="stylesheet">
 <link href="${url_base}/static/css/lib/materialdesignicons.min.css?v=001" rel="stylesheet">


### PR DESCRIPTION
When the page is saved on the homescreen it doesn't have a proper icon, but just a scaled-down screenshot of the app itself. This line display the Watcher monogram, which is already available in the repo.