### PR TITLE
Fix DOMException on manual download

### DIFF
--- a/static/js/library/status.js
+++ b/static/js/library/status.js
@@ -631,7 +631,8 @@ function manual_download(event, elem, guid, kind, imdbid){
 
     var $i = elem.querySelector('i.mdi');
     $i.classList.remove("mdi-download");
-    $i.classList.add("mdi-circle animated");
+    $i.classList.add("mdi-circle");
+    $i.classList.add("animated");
 
     var year = $movie_status_modal.find("div.modal-heade3wr span.year").text();
 


### PR DESCRIPTION
```Uncaught DOMException: Failed to execute 'add' on 'DOMTokenList': The token provided ('mdi-circle animated') contains HTML space characters, which are not valid in tokens.```