### PR TITLE
Added support for DanishBits

### DIFF
--- a/core/base_config.cfg
+++ b/core/base_config.cfg
@@ -90,6 +90,13 @@
     },
     "Indexers": {
         "NewzNab": {},
+        "PrivateTorrent": {
+            "danishbits": {
+                "enabled": false,
+                "username": "",
+                "passkey": ""
+            }
+        },
         "Torrent": {
             "extratorrent": false,
             "limetorrents": false,

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -71,10 +71,10 @@ class Url(object):
 
         Returns object requests response
         '''
-        if not expose_user_agent:
-            headers['User-Agent'] = random.choice(Url.user_agents)
-        else:
+        if expose_user_agent:
             headers['User-Agent'] = 'Watcher3'
+        else:
+            headers['User-Agent'] = random.choice(Url.user_agents)
 
         verifySSL = core.CONFIG.get('Server', {}).get('verifyssl', False)
 

--- a/core/helpers.py
+++ b/core/helpers.py
@@ -58,7 +58,7 @@ class Url(object):
         return s.lower().strip()
 
     @staticmethod
-    def open(url, post_data=None, timeout=30, headers={}, stream=False, proxy_bypass=False):
+    def open(url, post_data=None, timeout=30, headers={}, stream=False, proxy_bypass=False, expose_user_agent=False):
         ''' Assemles and executes requests call
         url (str): url to request
         post-data (dict): data to send via post                     <optional - default None>
@@ -71,8 +71,10 @@ class Url(object):
 
         Returns object requests response
         '''
-
-        headers['User-Agent'] = random.choice(Url.user_agents)
+        if not expose_user_agent:
+            headers['User-Agent'] = random.choice(Url.user_agents)
+        else:
+            headers['User-Agent'] = 'Watcher3'
 
         verifySSL = core.CONFIG.get('Server', {}).get('verifyssl', False)
 

--- a/core/providers/torrent.py
+++ b/core/providers/torrent.py
@@ -92,6 +92,16 @@ class Torrent(NewzNabProvider):
                         if i not in results:
                             results.append(i)
 
+        for indexer, indexerobject in core.CONFIG['Indexers']['PrivateTorrent'].items():
+            if indexerobject['enabled']:
+                if not hasattr(torrent_modules, indexer):
+                    logging.warning('Torrent indexer {} enabled but not found in torrent_modules.'.format(indexer))
+                    continue
+                else:
+                    for i in getattr(torrent_modules, indexer).search(imdbid, term):
+                        if i not in results:
+                            results.append(i)
+
         return results
 
     def get_rss(self):

--- a/core/providers/torrent_modules/danishbits.py
+++ b/core/providers/torrent_modules/danishbits.py
@@ -1,0 +1,77 @@
+import core
+import logging
+from core.helpers import Url
+import json
+
+logging = logging.getLogger(__name__)
+
+
+def search(imdbid, term):
+    ''' Search api for movie
+    imdbid (str): imdb id #
+
+    Returns list of dicts of parsed releases
+    '''
+
+    proxy_enabled = core.CONFIG['Server']['Proxy']['enabled']
+    username = core.CONFIG['Indexers']['PrivateTorrent']['danishbits']['username']
+    passkey = core.CONFIG['Indexers']['PrivateTorrent']['danishbits']['passkey']
+
+    logging.info('Performing backlog search on DanishBits for {}.'.format(imdbid))
+
+    try:
+        url = 'https://danishbits.org/couchpotato.php?user={}&passkey={}&imdbid={}'.format(username, passkey, imdbid)
+
+        if proxy_enabled and core.proxy.whitelist('https://danishbits.org') is True:
+            response = Url.open(url, proxy_bypass=True, expose_user_agent=True).text
+        else:
+            response = Url.open(url, expose_user_agent=True).text
+
+        results = json.loads(response).get('results')
+        if results:
+            return _parse(results, imdbid=imdbid)
+        else:
+            logging.info('Nothing found on DanishBits')
+            return []
+    except (SystemExit, KeyboardInterrupt):
+        raise
+    except Exception as e:
+        logging.error('DanishBits search failed.', exc_info=True)
+        return []
+
+
+def _parse(results, imdbid=None):
+    ''' Parse api response
+    results (list): dicts of releases
+
+    Returns list of dicts
+    '''
+
+    logging.info('Parsing {} DanishBits results.'.format(len(results)))
+    item_keep = ('size', 'pubdate', 'title', 'indexer', 'info_link', 'guid', 'torrentfile', 'resolution', 'type', 'seeders')
+
+    parsed_results = []
+
+    for result in results:
+        parsed_result = {}
+        parsed_result['indexer'] = 'DanishBits'
+        parsed_result['info_link'] = result['details_url']
+        parsed_result['torrentfile'] = result['download_url']
+        parsed_result['guid'] = result['torrent_id']
+        parsed_result['type'] = 'torrent'
+        parsed_result['pubdate'] = result['publish_date']
+        parsed_result['seeders'] = result['seeders']
+        parsed_result['size'] = result['size'] * 1000000
+
+        parsed_result['imdbid'] = result['imdb_id']
+        parsed_result['status'] = 'Available'
+        parsed_result['score'] = 0
+        parsed_result['downloadid'] = None
+        logging.info('Title {} is freeleech {}'.format(result['release_name'], result['freeleech']))
+        parsed_result['freeleech'] = True
+        parsed_result['download_client'] = None
+        parsed_result['title'] = result['release_name']
+        parsed_results.append(parsed_result)
+
+    logging.info('Found {} results from DanishBits'.format(len(parsed_results)))
+    return parsed_results

--- a/core/providers/torrent_modules/danishbits.py
+++ b/core/providers/torrent_modules/danishbits.py
@@ -67,7 +67,6 @@ def _parse(results, imdbid=None):
         parsed_result['status'] = 'Available'
         parsed_result['score'] = 0
         parsed_result['downloadid'] = None
-        logging.info('Title {} is freeleech {}'.format(result['release_name'], result['freeleech']))
         parsed_result['freeleech'] = True
         parsed_result['download_client'] = None
         parsed_result['title'] = result['release_name']

--- a/core/providers/torrent_modules/danishbits.py
+++ b/core/providers/torrent_modules/danishbits.py
@@ -27,11 +27,16 @@ def search(imdbid, term):
         else:
             response = Url.open(url, expose_user_agent=True).text
 
-        results = json.loads(response).get('results')
+        responseobject = json.loads(response)
+        results = responseobject.get('results')
+
         if results:
             return _parse(results, imdbid=imdbid)
         else:
             logging.info('Nothing found on DanishBits')
+            errormsg = responseobject.get('error')
+            if errormsg:
+                logging.info('Error message: {}'.format(errormsg))
             return []
     except (SystemExit, KeyboardInterrupt):
         raise

--- a/static/js/settings/indexers.js
+++ b/static/js/settings/indexers.js
@@ -119,6 +119,19 @@ function _get_settings(){
         settings['Torrent'][checkbox.id] = is_checked(checkbox);
     });
 
+// INDEXERS['PRIVATETORRENT']
+    var required_fields = [];
+
+    var privateTrackers = {};
+
+    var danishbits = {};
+    danishbits.enabled = is_checked(document.querySelector("i[data-id='danishbits']"));
+    danishbits.username = document.querySelector("input[data-id='danishbits-username']").value;
+    danishbits.passkey = document.querySelector("input[data-id='danishbits-passkey']").value;
+    privateTrackers['danishbits'] = danishbits;
+
+    settings['PrivateTorrent'] = privateTrackers;
+
     if(blanks == true){
         return false;
     };

--- a/static/js/settings/indexers.js
+++ b/static/js/settings/indexers.js
@@ -120,15 +120,28 @@ function _get_settings(){
     });
 
 // INDEXERS['PRIVATETORRENT']
-    var required_fields = [];
-
     var privateTrackers = {};
 
-    var danishbits = {};
-    danishbits.enabled = is_checked(document.querySelector("i[data-id='danishbits']"));
-    danishbits.username = document.querySelector("input[data-id='danishbits-username']").value;
-    danishbits.passkey = document.querySelector("input[data-id='danishbits-passkey']").value;
-    privateTrackers['danishbits'] = danishbits;
+    each(document.querySelectorAll("form[data-category='privtorrent'] > div"), function(dataelement){
+        var key = dataelement.dataset.id;
+
+        if (privateTrackers[key] == null) {
+            privateTrackers[key] = {};
+        }
+
+        var enabledelement = dataelement.querySelector('i.c_box');
+        if(enabledelement != null) {
+            privateTrackers[key]["enabled"] = is_checked(enabledelement);
+        }
+
+        var inputelements = dataelement.querySelectorAll('input');
+        if (inputelements != null) {
+            each(inputelements, function (inputelement) {
+                var inputId = inputelement.dataset.id;
+                privateTrackers[key][inputId] = inputelement.value;
+            });
+        }
+    });
 
     settings['PrivateTorrent'] = privateTrackers;
 

--- a/static/js/settings/indexers.js
+++ b/static/js/settings/indexers.js
@@ -134,13 +134,10 @@ function _get_settings(){
             privateTrackers[key]["enabled"] = is_checked(enabledelement);
         }
 
-        var inputelements = dataelement.querySelectorAll('input');
-        if (inputelements != null) {
-            each(inputelements, function (inputelement) {
-                var inputId = inputelement.dataset.id;
-                privateTrackers[key][inputId] = inputelement.value;
-            });
-        }
+        each(dataelement.querySelectorAll('input'), function (inputelement) {
+            var inputId = inputelement.dataset.id;
+            privateTrackers[key][inputId] = inputelement.value;
+        });
     });
 
     settings['PrivateTorrent'] = privateTrackers;

--- a/templates/settings/indexers.html
+++ b/templates/settings/indexers.html
@@ -182,6 +182,24 @@
                 </div>
             </form>
 
+            <h1>Private Torrent Indexers</h1>
+            <form class="form-group row bg-light rounded mx-auto py-3" data-category="privtorrent">
+                <div class="input-group col-md-12">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text">
+                            <i class="mdi mdi-checkbox-blank-outline c_box" data-id="danishbits" title="Enabled" value="${config['PrivateTorrent']['danishbits']['enabled']}"></i>
+                        </span>
+                    </div>
+                    <span class="input-group-item form-control">
+                        DanishBits
+                    </span>
+                </div>
+                <div class="input-group col-md-12">
+                    <input class="form-control" type="text" data-id="danishbits-username" placeholder="Username" value="${config['PrivateTorrent']['danishbits']['username']}"/>
+                    <input class="form-control" type="text" data-id="danishbits-passkey" placeholder="Passkey" value="${config['PrivateTorrent']['danishbits']['passkey']}"/>
+                </div>
+            </form>
+
             <button id="save_settings" class="btn btn-success float-right" onclick="save_settings(event, this)">
                 <i class="mdi mdi-content-save"></i>
 

--- a/templates/settings/indexers.html
+++ b/templates/settings/indexers.html
@@ -183,20 +183,22 @@
             </form>
 
             <h1>Private Torrent Indexers</h1>
-            <form class="form-group row bg-light rounded mx-auto py-3" data-category="privtorrent">
-                <div class="input-group col-md-6 col-sm-12" data-id="danishbits">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text">
-                            <i class="mdi mdi-checkbox-blank-outline c_box" data-id="enabled" title="Enabled" value="${config['PrivateTorrent']['danishbits']['enabled']}"></i>
+            <form class="mx-auto" data-category="privtorrent">
+                <div class="row bg-light rounded mx-auto py-3" data-id="danishbits">
+                    <div class="input-group col-md-6 col-sm-12">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text">
+                                <i class="mdi mdi-checkbox-blank-outline c_box" data-id="enabled" title="Enabled" value="${config['PrivateTorrent']['danishbits']['enabled']}"></i>
+                            </span>
+                        </div>
+                        <span class="input-group-item form-control">
+                            DanishBits
                         </span>
                     </div>
-                    <span class="input-group-item form-control">
-                        DanishBits
-                    </span>
-                </div>
-                <div class="input-group col-md-6 col-sm-12" data-id="danishbits">
-                    <input class="form-control" type="text" data-id="username" placeholder="Username" value="${config['PrivateTorrent']['danishbits']['username']}"/>
-                    <input class="form-control" type="text" data-id="passkey" placeholder="Passkey" value="${config['PrivateTorrent']['danishbits']['passkey']}"/>
+                    <div class="input-group col-md-6 col-sm-12">
+                        <input class="form-control" type="text" data-id="username" placeholder="Username" value="${config['PrivateTorrent']['danishbits']['username']}"/>
+                        <input class="form-control" type="text" data-id="passkey" placeholder="Passkey" value="${config['PrivateTorrent']['danishbits']['passkey']}"/>
+                    </div>
                 </div>
             </form>
 

--- a/templates/settings/indexers.html
+++ b/templates/settings/indexers.html
@@ -184,19 +184,19 @@
 
             <h1>Private Torrent Indexers</h1>
             <form class="form-group row bg-light rounded mx-auto py-3" data-category="privtorrent">
-                <div class="input-group col-md-12">
+                <div class="input-group col-md-6 col-sm-12" data-id="danishbits">
                     <div class="input-group-prepend">
                         <span class="input-group-text">
-                            <i class="mdi mdi-checkbox-blank-outline c_box" data-id="danishbits" title="Enabled" value="${config['PrivateTorrent']['danishbits']['enabled']}"></i>
+                            <i class="mdi mdi-checkbox-blank-outline c_box" data-id="enabled" title="Enabled" value="${config['PrivateTorrent']['danishbits']['enabled']}"></i>
                         </span>
                     </div>
                     <span class="input-group-item form-control">
                         DanishBits
                     </span>
                 </div>
-                <div class="input-group col-md-12">
-                    <input class="form-control" type="text" data-id="danishbits-username" placeholder="Username" value="${config['PrivateTorrent']['danishbits']['username']}"/>
-                    <input class="form-control" type="text" data-id="danishbits-passkey" placeholder="Passkey" value="${config['PrivateTorrent']['danishbits']['passkey']}"/>
+                <div class="input-group col-md-6 col-sm-12" data-id="danishbits">
+                    <input class="form-control" type="text" data-id="username" placeholder="Username" value="${config['PrivateTorrent']['danishbits']['username']}"/>
+                    <input class="form-control" type="text" data-id="passkey" placeholder="Passkey" value="${config['PrivateTorrent']['danishbits']['passkey']}"/>
                 </div>
             </form>
 


### PR DESCRIPTION
I thought it might be a good idea to add support for private torrent trackers.

This pull request adds support for [DanishBits][1]

Is the structure of the config okay? I didn't want to break the settings of existing installations by changing the structure a whole lot.

Expose useragent: Instead of scraping, indicating the user agent to the tracker might be a good idea.

DanishBits uses an integer for identifing a torrent. So currently, the torrent guid is just an integer. This might be bad when also using other trackers.

I have tried to match your style of the settings.

I would love to hear feedback.

[1]: https://danishbits.org