### PR TITLE
Corrected default config for torrent downloads and minor typing errors

### DIFF
--- a/core/base_config.cfg
+++ b/core/base_config.cfg
@@ -1,7 +1,7 @@
 {
     "Downloader": {
         "Sources": {
-            "torrentenabled": false,
+            "torrentenabled": true,
             "usenetenabled": true
         },
         "Torrent": {

--- a/static/js/settings/downloader.js
+++ b/static/js/settings/downloader.js
@@ -103,7 +103,7 @@ function _get_settings(){
     settings["Usenet"] = {};
     var blanks = false;
 
-// DOWNLAODER['USENET']
+// DOWNLOADER['USENET']
     each(document.querySelectorAll("div#usenet_client_settings > div"), function(client){
         var name = client.id;
         var config = {};
@@ -120,7 +120,7 @@ function _get_settings(){
         settings['Usenet'][name] = config;
     });
 
-// DOWNLAODER['TORRENT']
+// DOWNLOADER['TORRENT']
     each(document.querySelectorAll("div#torrent_client_settings > div"), function(client){
         var name = client.id;
         var config = {};


### PR DESCRIPTION
If you are using the default torrentdownloader setting, you might think that torrent is enabled. But that's only in the settings page (visual) in reality, some of the code asks if torrents are enabled and the default setting is false.

Changed it to true and also found 2 minor typing errors while looking at the code.