### PR TITLE
fix escaping single quotation marks for guid on status page

### DIFF
--- a/static/js/library/status.js
+++ b/static/js/library/status.js
@@ -452,6 +452,7 @@ function _results_table(results){
 
         result["translated_status"] = _(result["status"]);
         result['status_color'] = status_colors[result['status']]
+        result['guid'] = result['guid'].replace(/'/g, "\\'");
         rows += format_template(templates.release, result).outerHTML;
     });
 


### PR DESCRIPTION
This resolves the problems with the download of movie release with single quotation marks in the title i.e. Ocean's 8.