### PR TITLE
Fix regression downloadvolumefactor must be converted to float

### DIFF
--- a/core/providers/base.py
+++ b/core/providers/base.py
@@ -153,7 +153,7 @@ class NewzNabProvider(object):
                 result = {
                     "download_client": None,
                     "downloadid": None,
-                    "freeleech": 1 if item['attr'].get('downloadvolumefactor', 1) == 0 else 0,
+                    "freeleech": float(item['attr'].get('downloadvolumefactor', 1)) == 0.0,
                     "guid": guid,
                     "indexer": indexer,
                     "info_link": item.get('comments', '').split('#')[0],


### PR DESCRIPTION
Commit f5402252a12eaea6f36929748902f271a9e8bfe6 introduced a bug that
causes freeleech to always be False (0).
Root cause: comparing a non-empty string to zero always returns False.

The downloadvolumefactor property is a string that may contain either
an integer or floating point number. In order for freeleech to be true,
downloadvolumefactor must be zero. Since running floats through int()
will cause rounding to the nearest integer ('0.2' -> 0), we must
instead run the string through float and check for 0.0.
If downloadvolumefactor is anything other than '0' or '0.0', freeleech
will be False, as expected.