### PR TITLE
Add an indicator when trailer is loading

### DIFF
--- a/static/css/add_movie.css
+++ b/static/css/add_movie.css
@@ -68,7 +68,27 @@ img.poster{
     max-height: 18em;
 }
 
-iframe#trailer {
+preload-icon {
+    display: none;
+}
+
+preload-icon.loading {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+
+preload-icon > .mdi {
+    font-size: 3em;
+    width: initial;
+}
+
+iframe#trailer.unavailable {
     background: url("../images/trailer_unavailable.png") no-repeat 50% 50%;
 }
 

--- a/static/js/add_movie.js
+++ b/static/js/add_movie.js
@@ -216,8 +216,11 @@ function show_details(event, elem){
                                             "year": movie["title"]
                                             })
     .done(function(r){
+        document.querySelector('#trailer + preload-icon').classList.remove('loading');
         if(r){
             $modal.find("iframe#trailer").attr("src", `https://www.youtube.com/embed/${r}?&showinfo=0`);
+        } else {
+            document.getElementById('trailer').classList.add('unavailable');
         }
     });
 }

--- a/templates/add_movie.html
+++ b/templates/add_movie.html
@@ -145,7 +145,7 @@
                                     <img src="{poster_url}" class="img-responsive">
                                 </div>
                                 <div class="col-md-7">
-                                    <div class="embed-responsive embed-responsive-16by9 loading">
+                                    <div class="embed-responsive embed-responsive-16by9">
                                         <iframe src id="trailer"></iframe>
                                         <preload-icon class="loading">
                                             <i class="mdi mdi-circle animated"/></i>

--- a/templates/add_movie.html
+++ b/templates/add_movie.html
@@ -145,8 +145,11 @@
                                     <img src="{poster_url}" class="img-responsive">
                                 </div>
                                 <div class="col-md-7">
-                                    <div class="embed-responsive embed-responsive-16by9">
-                                        <iframe src="" id="trailer"></iframe>
+                                    <div class="embed-responsive embed-responsive-16by9 loading">
+                                        <iframe src id="trailer"></iframe>
+                                        <preload-icon class="loading">
+                                            <i class="mdi mdi-circle animated"/></i>
+                                        </preload-icon>
                                     </div>
                                     <p class="plot">{overview}</p>
                                 </div>


### PR DESCRIPTION
This prevents the `trailer_unavailable` image from appearing when the
Add Movie `details` modal first opens and the trailer has not yet been
loaded. Instead, the app's "busy/loading" indicator is shown until
the AJAX call completes. On success, embed the trailer. On failure,
display the `trailer_unavailable` image.