### PR TITLE
Fix bug displaying pointer cursor on movie cards

### DIFF
--- a/static/css/add_movie.css
+++ b/static/css/add_movie.css
@@ -20,10 +20,6 @@ ul#movies li{
     text-align: center;
 }
 
-.card{
-    cursor: pointer;
-}
-
 .card-body{
     padding: 0.5em 0.25em;
 }


### PR DESCRIPTION
The cards on the Add Movie page display the "hand" pointer cursor on
hover even though clicking performs no action. Switch to default cursor.
Proper pointer cursor still properly displays when hovering clickable items.