### PR TITLE
Create a torrent file from info-hash according to bep_0009

### DIFF
--- a/core/downloaders/BlackHole.py
+++ b/core/downloaders/BlackHole.py
@@ -165,7 +165,38 @@ def _download_magnet(data, path):
             continue
 
     logging.warning('Torrent hash {} not found on any torrent cache.'.format(magnet_hash))
-    return False
+
+    logging.warning('Creating a torrent file from hash {}.'.format(magnet_hash))
+
+    tf_elements = ['d10:magnet-uri',
+                   'LENGTH',
+                   'magnet:?xt=urn:btih:',
+                   magnet_hash,
+                   '&dn=',
+                   magnet_hash,
+                   '&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce',
+                   '&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce',
+                   '&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337',
+                   '&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969',
+                   '&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337',
+                   '&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce',
+                   '&tr=udp%3A%2F%2Ftracker.zer0day.to%3A1337%2Fannounce',
+                   '&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce',
+                   'e']
+
+    # calculate and update the lenght of magnet file
+    mlenght = 0
+
+    for a in tf_elements[2:-1]:
+        mlenght += len(a)
+
+    tf_elements[1] = str(mlenght) + ":"
+
+    torrent_file = "".join(tf_elements)
+
+    with open(path, 'w') as f:
+        f.write(torrent_file)
+    return True
 
 
 def _verify_torrent(stream, magnet):


### PR DESCRIPTION
When BlackHole.py fails to download a torrent file from cache sites,
it creates one using only the info-hash to download the complete one
with meta-data from the swarm, according to bep_0009 and similarly to
a magnet link.

I should add that I've only tested it with rTorrent 0.9.6