### PR TITLE
Fix Zooqle result parsing

### DIFF
--- a/core/providers/torrent_modules/zooqle.py
+++ b/core/providers/torrent_modules/zooqle.py
@@ -65,8 +65,8 @@ def _parse(xml, imdbid):
             result['imdbid'] = imdbid
             result['indexer'] = 'Zooqle'
             result['info_link'] = i.find('guid').text
-            result['torrentfile'] = i[8].text
-            result['guid'] = i[7].text.lower()
+            result['torrentfile'] = i[9].text
+            result['guid'] = i[8].text.lower()
             result['type'] = 'magnet'
             result['downloadid'] = None
             result['freeleech'] = 0

--- a/core/providers/torrent_modules/zooqle.py
+++ b/core/providers/torrent_modules/zooqle.py
@@ -71,7 +71,7 @@ def _parse(xml, imdbid):
             result['downloadid'] = None
             result['freeleech'] = 0
             result['download_client'] = None
-            result['seeders'] = int(i[9].text)
+            result['seeders'] = int(i[10].text)
 
             results.append(result)
         except Exception as e:


### PR DESCRIPTION
Currently the Zooqle result parser reports errors in the logs, the "no. of seeders" is pointing to the \<torrent:magnetURI\> XML element (the format was probably changed). I've fixed it by pointing it to the following element.

Maybe would be more robust searching for it using `find` as other elements in the `_parse` function.